### PR TITLE
Added github upload ssh key coder module

### DIFF
--- a/coder/templates/bootcamp/README.md
+++ b/coder/templates/bootcamp/README.md
@@ -38,6 +38,11 @@ a service account:
 1. Generate a **JSON private key**, which will be what you provide to Coder
    during the setup process.
 
+#### External Authentication - GitHub
+1. Create a GitHub App and complete the coderd environment setup by following the steps mentioned [here](https://coder.com/docs/admin/external-auth#github).
+
+1. Use the value set for `CODER_EXTERNAL_AUTH_0_ID` environment variable as the value for the terraform variable `github_app_id` in `terraform.tfvars` file.
+
 ### Architecture
 
 This template provisions the following resources:

--- a/coder/templates/bootcamp/terraform.tfvars.example
+++ b/coder/templates/bootcamp/terraform.tfvars.example
@@ -5,6 +5,7 @@ machine_type = "e2-medium"
 pd_size = 10
 github_repo = "github_repo_url"
 github_branch = "main"
+github_app_id = "primary-github"
 container_image = "docker_image:tag"
 jupyterlab = "true"
 codeserver = "true"

--- a/coder/templates/bootcamp/variables.tf
+++ b/coder/templates/bootcamp/variables.tf
@@ -41,6 +41,10 @@ variable github_branch {
     type = string
 }
 
+variable github_app_id {
+    type = string
+}
+
 variable container_image {
     type = string
 }


### PR DESCRIPTION
Coder module details - https://registry.coder.com/modules/coder/github-upload-public-key

This allows users to link their GitHub account to their Coder workspaces.